### PR TITLE
Improve site accessibility for people using screen readers

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -33,12 +33,12 @@
 - name: This Website!
   icon: 💾
   rating: 2
-  description: My online resume and blog, developed with Jekyll, HTML5, SASS, and JavaScript. Built with a mobile-first responsive design.
+  description: My online resume and blog, developed with Jekyll, HTML5, Sass, and JavaScript. Built with a mobile-first responsive design.
   url: https://github.com/AleksandrHovhannisyan/aleksandrhovhannisyan.github.io
   topics:
     - jekyll
     - html5
-    - scss
+    - sass
     - javascript
 
 - name: Embody

--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -21,7 +21,7 @@
       rating: 5
     - name: React (+Ant Design)
       rating: 5
-    - name: SQL (Oracle, postgres)
+    - name: SQL
       rating: 4
     - name: NodeJS, Express
       rating: 3

--- a/_includes/code.html
+++ b/_includes/code.html
@@ -1,12 +1,19 @@
 <div class="code-header">
     {% if include.file %}
     <div class="file-name-container">
-        <div class="file-name">{{ include.file }}</div>
+        <h6 class="file-name" 
+            role="heading" 
+            aria-label="File name: {{ include.file }}">
+            {{ include.file }}
+        </h6>
     </div>
     {% endif %}
     {% unless include.copyable == false %}
     <div class="copy-code-container">
-        <div class="copy-code-button" data-code="{{ include.code | escape }}" title="Copy to clipboard" tabindex="0"></div>
+        <button class="copy-code-button"
+             aria-label="Copy code block to your clipboard" 
+             data-code="{{ include.code | escape }}"
+        ></button>
     </div>
     {% endunless %}
 </div>

--- a/_includes/headingWithImage.html
+++ b/_includes/headingWithImage.html
@@ -2,5 +2,5 @@
 {% assign lvl = include.lvl %}
 <h{{ lvl }} class="heading-with-image">
     <span>{{ h }}</span>
-    <img src="{{ include.img }}" alt="{{ include.alt }}">
+    <img src="{{ include.img }}" alt="{{ include.alt }}" aria-hidden="true">
 </h{{ lvl }}>

--- a/_includes/postPreview.html
+++ b/_includes/postPreview.html
@@ -1,17 +1,17 @@
 {% assign post = include.post %}
-<div class="card post-preview" tabindex="0">
-    <a class="container-link" href="{{ post.url }}" tabindex="-1"></a>
+<div class="card post-preview">
     <header class="post-preview-header">
         {% include posts/thumbnail.html post=post %}
-        <h2 class="post-title">{{ post.title }}</h2>
+        <h2 class="post-title" aria-label="Title: {{ post.title }}">{{ post.title }}</h2>
     </header>
+    <a class="container-link" href="{{ post.url }}" aria-label="Read this blog post"></a>
     <div class="post-preview-body">
         {% include posts/meta.html content=post.content date=post.date %}
         <p class="post-description">{{ post.description | truncate: 160 }}</p>
-        <footer class="post-tags">
+        <ul class="post-tags" aria-label="Tags belonging to this blog post.">
             {% for tag in post.tags limit: 4 %}
-            <a href="/tag/{{ tag }}" class="post-tag tag" title="View posts tagged as {{ tag }}">{{ tag }}</a>
+            <li><a href="/tag/{{ tag }}" title="View posts tagged as {{ tag }}" class="post-tag tag">{{ tag }}</a></li>
             {% endfor %}
-        </footer>
+        </ul>
     </div>
 </div>

--- a/_includes/posts/meta.html
+++ b/_includes/posts/meta.html
@@ -4,28 +4,22 @@
     {% if include.showProfilePhoto %}
     <img src="/assets/img/profile-photo.png" alt="By Aleksandr Hovhannisyan" class="meta author-photo" />
     {% endif %}
-    <div class="post-date meta-wrapper">
-        <div class="meta">
-            {% include svg.html svg="calendar" class="meta-icon" %}
-            {{ include.date | date: "%b %-d, %Y" }}
-        </div>
+    <div class="meta post-date-published">
+        {% include svg.html svg="calendar" class="meta-icon" %}
+        <time datetime="{{ include.date | date: "%Y-%m-%d" }}">{{ include.date | date: "%b %-d, %Y" }}</time>
     </div>
     {% if include.lastUpdated %}
-    <div class="last-updated meta-wrapper">
-        <div class="meta">
-            {% include svg.html svg="info" class="meta-icon" %}
-            Updated: {{ include.lastUpdated | date: "%b %-d, %Y" }}
-        </div>
+    <div class="meta post-date-updated">
+        {% include svg.html svg="info" class="meta-icon" %}
+        <time datetime="{{ include.lastUpdated | date: "%Y-%m-%d" }}">Updated: {{ include.lastUpdated | date: "%b %-d, %Y" }}</time>
     </div>
     {% endif %}
-    <div class="post-reading-length meta-wrapper">
-        <div class="meta">
-            {% include svg.html svg="clock" class="meta-icon" %}
-            {{ minutes }} min read
-        </div>
+    <div class="meta post-reading-length">
+        {% include svg.html svg="clock" class="meta-icon" %}
+        <span>{{ minutes }} min read</span>
     </div>
     {% if include.tags %}
-    <div class="post-tags meta-wrapper">
+    <div class="meta post-tags" role="list" aria-label="Tags belonging to this blog post.">
         {% for tag in include.tags %}
         <a href="/tag/{{ tag }}" class="tag post-tag">{{ tag }}</a>
         {% endfor %}

--- a/_includes/posts/thumbnail.html
+++ b/_includes/posts/thumbnail.html
@@ -7,6 +7,6 @@
     <img 
         data-src="/assets/img/posts/{{ post.slug }}/thumbnail.PNG" 
         src="/assets/img/posts/{{ post.slug }}/thumbnail-placeholder.PNG" 
-        alt="Post thumbnail" 
+        alt="Blog post thumbnail" 
         class="placeholder" />
 </picture>

--- a/_includes/projectCard.html
+++ b/_includes/projectCard.html
@@ -1,23 +1,23 @@
 {% assign project = include.project %}
-<div class="card project" tabindex="0">
+<div class="card project">
     <header>
         <div class="project-name">
-            <span class="project-icon">{{ project.icon }}</span>
-            <span>{{ project.name }}</span>
+            <span class="project-icon" aria-hidden="true">{{ project.icon }}</span>
+            <h3 class="name" aria-label="Project: {{ project.name }}">{{ project.name }}</h3>
         </div>
-        <div class="project-rating">
+        <div class="project-rating" role="img" aria-label="This project has {{ project.rating }} stars on GitHub">
             {% include svg.html svg="star" class="star star-filled" %}
             <span>{{ project.rating }}</span>
         </div>
     </header>
     <p class="project-description">{{ project.description }}</p>
-    <footer class="topics">
+    <ul class="topics" aria-label="Technologies used on this project">
         {% for topic in project.topics %}
-        <div class="topic tag">{{ topic }}</div>
+        <li class="topic tag">{{ topic }}</li>
         {% endfor %}
-    </footer>
-    <a class="container-link" href="{{ project.url }}" tabindex="-1"></a>
-    <div class="hover-content">
+    </ul>
+    <a class="container-link" href="{{ project.url }}" aria-label="Explore {{ project.name }} on GitHub"></a>
+    <div class="hover-content" aria-hidden="true">
         Explore on GitHub
         {% include svg.html svg="external-link" %}
     </div>

--- a/_includes/tooltip.html
+++ b/_includes/tooltip.html
@@ -1,4 +1,4 @@
-<div class="tooltip tooltip-{{ include.position }}">
+<div class="tooltip tooltip-{{ include.position }}" aria-hidden="true">
     <div class="tooltip-text">
         {{ include.text }}
     </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -14,19 +14,22 @@ layout: default
     site.data.tagDescriptions["all"]}} {% endif %}
   </p>
   {% assign primaryTags = "all,dev,computer-science,gaming,writing" | split: ',' %}
-  <ul class="tag-navigation">
-    {% for tag in primaryTags %}
-    <li>
-        <a
-          href="{% if tag == "all" %}/blog/{% else %}/tag/{{ tag }}{% endif %}"
-          class="post-tag tag{% if page.tag == tag %} active-tag{% endif %}"
-          title="View posts tagged as {{ tag }}"
-        >
-          {{ tag }}
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+  <nav aria-label="Primary blog post tags">
+    <ul class="tag-navigation">
+      {% for tag in primaryTags %}
+      <li>
+          <a
+            href="{% if tag == "all" %}/blog/{% else %}/tag/{{ tag }}{% endif %}"
+            class="post-tag tag{% if page.tag == tag %} active-tag{% endif %}"
+            title="View posts tagged as {{ tag }}"
+            {% if page.tag == tag %}aria-current="true"{% endif %}
+          >
+            {{ tag }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
   <section class="post-preview-grid card-grid">
     {{ content }}
   </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,24 +42,28 @@
         </script>
     </head>
     <body>
+        <a href="#page-content" class="screen-reader-only skip-navigation">Skip main navigation</a>
         <header>
             <nav id="topnav">
                 <div class="nav-container">
                     <a id="home-link" href="/">
-                        <img src="/favicon.png" alt="(Ah)" id="logo" />
+                        <img src="/favicon.png" alt="Logo" id="logo" />
                         <span id="website-name">{{ site.title }}</span>
                     </a>
-                    {% include svg.html svg="hamburger" class="navbar-hamburger" %}
+                    <button class="navbar-toggle" aria-label="Toggle navigation menu.">
+                        {% include svg.html svg="hamburger" class="navbar-hamburger" %}
+                    </button>
                     <div class="nav-menu">
                         <ul class="nav-links">
-                            <li><a href="/experience" {% if page.title == "Experience" %}id="active-nav-link"{% endif %}>Experience</a></li>
-                            <li><a href="/blog" {% if page.isBlogPage %}id="active-nav-link"{% endif %}>Blog</a></li>
-                            <li><a href="/contact" {% if page.title == "Contact" %}id="active-nav-link"{% endif %}>Contact</a></li>
+                            {% assign navLinks = "Experience,Blog,Contact" | split: ',' %}
+                            {% for link in navLinks %}
+                                <li><a href="/{{ link | downcase }}" {% if page.title == link %}aria-current="page" id="active-nav-link"{% endif %}>{{ link }}</a></li>
+                            {% endfor %}
                             <li id="theme-switch-container">
                                 <!-- Inspiration: https://create-react-app.dev/ -->
-                                <div id="theme-switch" tabindex="0" title="Switch theme" aria-label="Theme switch">
-                                    <img id="moon" src="/assets/img/moon.png" alt="🌜" />
-                                    <img id="sun" src="/assets/img/sun.png" alt="🌞" />
+                                <div id="theme-switch" tabindex="0" title="Switch theme" role="button">
+                                    <img aria-hidden="true" id="moon" src="/assets/img/moon.png" alt="🌜" />
+                                    <img aria-hidden="true" id="sun" src="/assets/img/sun.png" alt="🌞" />
                                     <div id="knob"></div>
                                 </div>
                             </li>
@@ -73,7 +77,7 @@
         </main>
         <!-- Note: footer is not part of page wrapper to ensure it sticks to the bottom of the page -->
         <footer id="page-footer">
-            <span>Made with ♥ by {{ site.author }}, &copy; 2019–2020</span>
+            <span>Copyright {{ site.author }}, 2019–2020</span>
         </footer>
         <!-- Custom javascript -->
         <script src="/assets/scripts/common.js"></script>

--- a/_pages/experience.html
+++ b/_pages/experience.html
@@ -4,111 +4,116 @@ description: I try to keep busy while having fun and testing my limits. Between 
 permalink: /experience/
 ---
 
-
-{% include banner.html heading="My experience" content="I try to keep busy while having fun and testing my limits. Between school, side projects, freelancing, and interning, I've gained valuable exposure to a wide variety of interesting technologies and problems." %}
+{% include banner.html heading="My experience" content="I try to keep busy while
+having fun and testing my limits. Between school, side projects, freelancing,
+and interning, I've gained valuable exposure to a wide variety of interesting
+technologies and problems." %}
 <section id="projects" class="section">
-    {% include headingWithImage.html h="Projects" lvl=2 img="/assets/img/folder.png" alt="📁" %}
-    <div id="project-grid" class="card-grid">
-        {% for project in site.data.projects %}
+  {% include headingWithImage.html h="Projects" lvl=2 img="/assets/img/folder.png" alt="📁" %}
+  <div id="project-grid" class="card-grid">
+    {% for project in site.data.projects %}
         {% include projectCard.html project=project %}
-        {% endfor %}
-        <div id="github-cta">
-            <header>
-                <p><strong>Want to see more of my work?</strong></p>
-            </header>
-            <div>
-                <p>Check out my other repos:</p>
-                <a href="https://github.com/AleksandrHovhannisyan?tab=repositories">{% include svg.html svg="github" %}</a>
-            </div>
-        </div>
+    {% endfor %}
+    <div id="github-cta">
+      <header>
+        <p><strong>Want to see more of my work?</strong></p>
+      </header>
+      <div>
+        <p>Check out my other repos:</p>
+        <a
+          aria-label="Aleksandr Hovhannisyan's GitHub profile."
+          href="https://github.com/AleksandrHovhannisyan?tab=repositories"
+          >{% include svg.html svg="github" %}</a>
+      </div>
     </div>
+  </div>
 </section>
 <section id="skills" class="section">
-    {% include headingWithImage.html h="Skills and Abilities" lvl=2 img="/assets/img/juggler.png" alt="🤹" %}
-    <div id="skill-grid">
-        {% for item in site.data.skills %}
-        <div>
-            <h3 class="skill-category">{{ item.category }}</h3>
-            {% for skill in item.skills %}
-            <div class="skill-item">
-                <span class="skill-name">{{ skill.name }}</span>
-                <div class="skill-rating">
-                    {% for i in (1..skill.rating) %}
-                    {% include svg.html svg="star" class="star star-filled" %}
-                    {% endfor %}
-                    {% assign j = skill.rating | plus: 1 %}
-                    {% for i in (j..5) %}
-                    {% include svg.html svg="star" class="star star-empty" %}
-                    {% endfor %}
-                    {% assign rating = '' %}
-                    {% if skill.rating == 1 %}{% assign rating = 'Familiar' %}
-                    {% elsif skill.rating == 2 %}{% assign rating = 'Basic' %}
-                    {% elsif skill.rating == 3 %}{% assign rating = 'Intermediate' %}
-                    {% elsif skill.rating == 4 %}{% assign rating = 'Competent' %}
-                    {% elsif skill.rating == 5 %}{% assign rating = 'Advanced' %}
-                    {% endif %}
-                    {% include tooltip.html position='top' text=rating %}
-                </div>
-            </div>
+  {% include headingWithImage.html h="Skills and Abilities" lvl=2
+  img="/assets/img/juggler.png" alt="🤹" %}
+  <div id="skill-grid">
+    {% assign skillMap = "Familiar,Basic,Intermediate,Competent,Advanced" | split: ',' %}
+    {% for item in site.data.skills %}
+    <div>
+      <h3 class="skill-category" aria-label="Skill category: {{ item.category }}">{{ item.category }}</h3>
+      {% for skill in item.skills %}
+      {% assign skillLabelIndex = skill.rating | minus: 1 %}
+      <div class="skill-item">
+        <span class="skill-name">{{ skill.name }}</span>
+        <div class="skill-rating" role="img" aria-label="Experience level: {{ skillMap[skillLabelIndex] }}">
+            {% for i in (1..skill.rating) %}
+                {% include svg.html svg="star" class="star star-filled" %}
             {% endfor %}
+            {% assign j = skill.rating | plus: 1 %}
+            {% for i in (j..5) %}
+                {% include svg.html svg="star" class="star star-empty" %}
+            {% endfor %}
+            {% assign rating = skillMap[skillLabelIndex] %}
+            {% include tooltip.html position='top' text=rating %}
         </div>
-        {% endfor %}
+      </div>
+      {% endfor %}
     </div>
+    {% endfor %}
+  </div>
 </section>
 <section id="work-experience" class="section">
-    {% include headingWithImage.html h="Work Experience" lvl=2 img="/assets/img/briefcase.png" alt="💼" %}
-    <section class="card-grid">
+  {% include headingWithImage.html h="Work Experience" lvl=2 img="/assets/img/briefcase.png" alt="💼" %}
+  <section class="card-grid">
     {% for job in site.data.work %}
-        <section class="job">
-            <header>
-                <h3 class="job-title">{{ job.title }}, {{ job.company }}</h3>
-                <p class="date-range">{{ job.dateRange }}</p>
-            </header>
-            <ul class="responsibilities" >
-                {% for responsibility in job.responsibilities %}
-                <li>{{ responsibility }}</li>
-                {% endfor %}
-            </ul>
-            <footer class="technologies-used">
-                {% for tech in job.tech %}
-                <div class="tag tech {{tech}}">{{tech}}</div>
-                {% endfor %}
-            </footer>
-        </section>
-    {% endfor %}
+    <section class="job">
+      <header>
+        <h3 class="job-title" aria-label="Position: {{ job.title}} at {{ job.company }}">{{ job.title }}, {{ job.company }}</h3>
+        <p class="date-range">{{ job.dateRange }}</p>
+      </header>
+      <ul class="responsibilities" aria-label="Responsibilities and work completed">
+        {% for responsibility in job.responsibilities %}
+        <li>{{ responsibility }}</li>
+        {% endfor %}
+      </ul>
+      <ul class="technologies-used" aria-label="Technologies used on this job">
+        {% for tech in job.tech %}
+        <li class="tag tech {{tech}}">{{tech}}</li>
+        {% endfor %}
+      </ul>
     </section>
+    {% endfor %}
+  </section>
 </section>
 <section id="education" class="section">
-    {% include headingWithImage.html h="Education" lvl=2 img="/assets/img/graduation-cap.png" alt="🎓" %}
-    {% for institution in site.data.education %}
-    <div class="institution collapsible collapsible-closed">
-        <header class="collapsible-header" tabindex="0">
-            <div>
-                <div class="institution-name">{{ institution.name }}</div>
-                <div class="institution-degree">{{ institution.degree }}</div>
-                <div class="institution-details">{{ institution.gpa }} GPA, {{ institution.years }}</div>
-            </div>
-        </header>
-        <div class="collapsible-content" aria-hidden="true">
-            <div class="courses">
-                <div class="section-title">Notable Coursework</div>
-                <ul>
-                    {% for course in institution.courses %}
-                    <li>{{ course }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
-            <div class="awards">
-                <div class="section-title">Awards and Recognitions</div>
-                <ul>
-                    {% for award in institution.awards %}
-                    <li>{{ award }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+  {% include headingWithImage.html h="Education" lvl=2 img="/assets/img/graduation-cap.png" alt="🎓" %}
+  {% for institution in site.data.education %}
+  <div class="institution collapsible collapsible-closed">
+    <header class="collapsible-header">
+      <div>
+        <div class="institution-name">{{ institution.name }}</div>
+        <div class="institution-degree">{{ institution.degree }}</div>
+        <div class="institution-details">
+          {{ institution.gpa }} GPA, {{ institution.years }}
         </div>
+      </div>
+      <button class="collapsible-toggle" aria-label="Toggle collapsible accordion"></button>
+    </header>
+    <div class="collapsible-content" aria-hidden="true">
+      <div class="courses">
+        <div class="section-title">Notable Coursework</div>
+        <ul>
+          {% for course in institution.courses %}
+          <li>{{ course }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="awards">
+        <div class="section-title">Awards and Recognitions</div>
+        <ul>
+          {% for award in institution.awards %}
+          <li>{{ award }}</li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
-    {% endfor %}
+  </div>
+  {% endfor %}
 </section>
 
 <!-- Currently only used on this page -->

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -9,7 +9,7 @@ permalink: /
         <h1 class="title">Hey there! I'm Aleksandr.</h1>
         <p class="subtitle">I'm a software developer with an eye for creating beautiful, responsive designs. I love learning new things and sharing my discoveries with others through writing.</p>
     </div>
-    <img src="/assets/img/profile-photo.png" alt="My profile photo" id="headshot" />
+    <img src="/assets/img/profile-photo.png" alt="Aleksandr Hovhannisyan headshot" id="headshot" />
 </section>
 <section id="featured-posts" class="section">
     <h2 class="heading">Recent Blog Posts</h2>
@@ -28,7 +28,7 @@ permalink: /
         {% include projectCard.html project=project %}
         {% endfor %}
         <div id="view-more-projects">
-            <a class="button hollow-button arrow-button" href="/experience/#projects">View more</a>
+            <a class="button hollow-button arrow-button" href="/experience/#projects" aria-label="View more of my projects">View more</a>
         </div>
     </div>
 </section>

--- a/_sass/components/card.scss
+++ b/_sass/components/card.scss
@@ -7,7 +7,7 @@
     box-shadow: 0 1px 1px rgba(0,0,0,0.15), 
                 0 2px 2px rgba(0,0,0,0.15), 
                 0 4px 4px rgba(0,0,0,0.15), 
-                0 8px 8px rgba(0,0,0,0.15);
+                0 6px 12px rgba(0,0,0,0.15);
     display: grid;
     grid-template-columns: 1fr;
     padding: var(--card-padding);
@@ -20,7 +20,7 @@
         box-shadow: 0 2px 2px rgba(0,0,0,0.15), 
                     0 4px 4px rgba(0,0,0,0.15), 
                     0 8px 8px rgba(0,0,0,0.15), 
-                    0 12px 12px rgba(0,0,0,0.15);
+                    0 8px 12px rgba(0,0,0,0.15);
         transform: translate(0, -5px);
 
         .hover-content {

--- a/_sass/components/collapsible.scss
+++ b/_sass/components/collapsible.scss
@@ -11,12 +11,25 @@
         .collapsible-header::before {
             transform: rotate(45deg);
         }
+
+        .collapsible-content {
+            visibility: hidden;
+        }
     }
 
     &.collapsible-open {
-        // Upward-pointing vector
-        .collapsible-header::before {
-            transform: rotate(-135deg);
+        .collapsible-header {
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+
+            // Upward-pointing vector
+            &::before {
+                transform: rotate(-135deg);
+            }
+        }
+
+        .collapsible-content {
+            visibility: visible;
         }
     }
 }
@@ -24,12 +37,23 @@
 .collapsible-header {
     background-color: var(--button-bg-color);
     border: none;
-    cursor: pointer;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-radius: 5px;
     display: flex;
     align-items: center;
-    padding: 10px;
+    padding: 0.5em;
+    position: relative;
+
+    .collapsible-toggle {
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 100%;
+        width: 100%;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        z-index: 2;
+    }
 
     &, * {
         @include transition(background-color, color, fill);
@@ -45,8 +69,8 @@
         content: "";
         border: solid;
         border-width: 0 2px 2px 0;
-        margin-left: 15px;
-        margin-right: 25px;
+        margin-left: 0.75em;
+        margin-right: 1.25em;
         padding: 3px;
         display: inline-block;
         @include transition(transform, border-color);
@@ -54,14 +78,13 @@
 }
 
 .collapsible-content {
+    --collapsible-content-border-width: 3px;
     border: solid var(--collapsible-content-border-width) var(--button-bg-color);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
     border-top: none;
     /* Will be set to a sufficiently large max-height by corresponding click handler for .collapsible */
     max-height: 0px;
     overflow: hidden;
-
-    --collapsible-content-border-width: 3px;
-    @include transition(max-height, color, border-color);
+    @include transition(max-height, color, border-color, visibility);
 }

--- a/_sass/components/topnav.scss
+++ b/_sass/components/topnav.scss
@@ -156,6 +156,14 @@ $topnav-min-height: 64px;
         }
     }
 
+    .navbar-toggle {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: transparent;
+        border: none;
+    }
+
     .navbar-hamburger {
         flex-shrink: 0;
         height: 27px;
@@ -205,7 +213,7 @@ $topnav-min-height: 64px;
             }
         }
     
-       .navbar-hamburger {
+        .navbar-toggle {
            display: none;
         }
     }

--- a/_sass/general/general.scss
+++ b/_sass/general/general.scss
@@ -3,6 +3,7 @@
 
 ::selection {
     background-color: var(--selection-bg-color);
+    color: black;
 }
 
 ::-webkit-scrollbar {
@@ -27,6 +28,27 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+}
+
+.screen-reader-only {
+    position: absolute;
+    left: -5000px;
+    z-index: 101;
+
+    &:focus {
+        left: 0;
+    }
+}
+
+.skip-navigation {
+    padding: 0.8em;
+    color: #dedede;
+    font-weight: map-get($font-weights, "normal");
+    @include transition(color, background-color);
+
+    &:focus {
+        background-color: #444647;
+    }
 }
 
 html {

--- a/_sass/pages/blog.scss
+++ b/_sass/pages/blog.scss
@@ -92,15 +92,13 @@
         }
 
         .post-description {
-            margin-bottom: 0px;
-            margin-top: 0px;
+            margin-bottom: 1em;
         }
 
         .post-tags {
             display: flex;
             flex-wrap: wrap;
             font-size: 0.875em;
-            margin-top: 1rem;
             z-index: 2;
             position: relative;
             

--- a/_sass/pages/blog.scss
+++ b/_sass/pages/blog.scss
@@ -101,6 +101,11 @@
             font-size: 0.875em;
             z-index: 2;
             position: relative;
+            list-style-type: none;
+
+            li {
+                margin: 0;
+            }
             
             .post-tag {
                 margin-bottom: 1em;
@@ -151,13 +156,9 @@
         }
     }
 
-    .meta-wrapper {
-        align-items: center;
-        display: flex;
-    }
-
     .post-tags {
         flex-wrap: wrap;
+        margin: 0;
 
         .post-tag {
             display: flex;
@@ -321,7 +322,6 @@
     }
 
     .code-header {
-        color: #bcbcbc;
         display: flex;
         background-color: #3b3b3b;
         border-top-left-radius: 5px;
@@ -336,11 +336,16 @@
         
         .file-name-container {
             display: flex;
+            align-items: center;
             flex: 2;
             justify-content: flex-start;
         }
 
         .file-name {
+            color: #bcbcbc;
+            font-size: 1rem;
+            font-weight: map-get($font-weights, "normal");
+            margin: 0;
             word-break: break-all;
             @include transition(color);
 
@@ -357,11 +362,15 @@
         }
 
         .copy-code-button {
+            border: none;
             align-items: center;
             cursor: pointer;
             display: flex;
-            padding-left: 6px;
-            padding-right: 6px;
+            font-size: 1rem;
+            background-color: #616161;
+            color: #e7e7e7;
+            padding: 0.4em 0.5em;
+            border-radius: 5px;
             @include transition(color, background-color);
 
             &::before {
@@ -375,8 +384,8 @@
             }
 
             &:focus, &:hover {
-                color: white;
-                background-color: #858585;
+                color: black;
+                background-color: #adadad;
             }
 
             &.copied {

--- a/_sass/pages/experience.scss
+++ b/_sass/pages/experience.scss
@@ -14,10 +14,16 @@
 
     .project-name {
         align-self: center;
-        color: var(--text-color-emphasis);
-        font-weight: map-get($font-weights, "bold");
         grid-area: heading;
         @include transition(color);
+
+        .name {
+            display: inline;
+            color: var(--text-color-emphasis);
+            font-size: 1rem;
+            margin: 0;
+            font-weight: map-get($font-weights, "bold");
+        }
     }
 
     .project-icon {
@@ -57,6 +63,7 @@
         display: flex;
         flex-wrap: wrap;
         grid-row: 3;
+        list-style-type: none;
     
         .topic {
             font-size: 0.875em;
@@ -104,7 +111,9 @@
     .skill-item {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        margin-bottom: 0.625em;
+        margin-bottom: 0.5em;
+        padding: 0.1em 0.25em;
+        border-radius: 5px;
         @include transition(background-color);
 
         &:hover {
@@ -176,11 +185,12 @@
             align-items: center;
             display: flex;
             padding-left: 1em;
+            list-style-type: none;
 
             .tech {
                 font-size: 0.875em;
-                padding: 0.25em 0.5em;
-                margin-right: 0.5em;
+                padding: 0.4em 0.8em;
+                margin: 0 0.5em 0.5em 0;
             }
 
             .react {

--- a/assets/scripts/collapsible.js
+++ b/assets/scripts/collapsible.js
@@ -1,39 +1,19 @@
-(function() {
+(function () {
   const collapsibles = document.querySelectorAll('.collapsible');
 
-  collapsibles.forEach(collapsible => {
-    const header = collapsible.querySelector('.collapsible-header');
-    header.addEventListener('click', () => {
-      toggleCollapsible(header);
+  collapsibles.forEach((collapsible) => {
+    const toggleButton = collapsible.querySelector('.collapsible-toggle');
+    toggleButton.addEventListener('click', (clickEvent) => {
+      toggleCollapsible(clickEvent.target);
     });
-    header.addEventListener('keyup', event => {
-      if (event.keyCode === 13) {
-        toggleCollapsible(event.target);
-      }
-    });
-
-    // Because all collapsibles are closed by default
-    disableContentAnchorFocus(collapsible);
   });
 })();
-
-function disableContentAnchorFocus(collapsible) {
-  collapsible.querySelectorAll('a').forEach(anchor => {
-    anchor.setAttribute('tabindex', '-1');
-  });
-}
-
-function enableContentAnchorFocus(collapsible) {
-  collapsible.querySelectorAll('a').forEach(anchor => {
-    anchor.setAttribute('tabindex', '0');
-  });
-}
 
 /** Called when a user clicks on a collapsible element's header.
  * Toggles the visibility of the collapsible's content.
  */
-function toggleCollapsible(header) {
-  const collapsible = header.parentElement;
+function toggleCollapsible(button) {
+  const collapsible = button.closest('.collapsible');
   const content = collapsible.querySelector('.collapsible-content');
   const collapsibleIsBeingOpened = collapsible.classList.contains('collapsible-closed');
 
@@ -42,11 +22,9 @@ function toggleCollapsible(header) {
     content.style.maxHeight = content.scrollHeight + 'px';
     content.scrollIntoView(true);
     content.setAttribute('aria-hidden', false);
-    enableContentAnchorFocus(collapsible);
   } else {
     collapsible.classList.replace('collapsible-open', 'collapsible-closed');
     content.style.maxHeight = '0px';
     content.setAttribute('aria-hidden', true);
-    disableContentAnchorFocus(collapsible);
   }
 }

--- a/assets/scripts/common.js
+++ b/assets/scripts/common.js
@@ -1,11 +1,11 @@
 'use strict';
 const html = document.documentElement;
 
-(function() {
+(function () {
   const themeSwitch = document.getElementById('theme-switch');
   themeSwitch.addEventListener('click', toggleColorTheme);
   // For accessibility, allow users to toggle with Enter
-  themeSwitch.addEventListener('keyup', keyEvent => {
+  themeSwitch.addEventListener('keyup', (keyEvent) => {
     if (keyEvent.keyCode === 13) {
       toggleColorTheme();
     }
@@ -33,16 +33,16 @@ function toggleMobileNavbarVisibility() {
   topnav.classList.toggle('expanded');
 }
 
-const navbarHamburger = topnav.querySelector('.navbar-hamburger');
-navbarHamburger.addEventListener('click', toggleMobileNavbarVisibility);
+const mobileNavbarToggle = topnav.querySelector('.navbar-toggle');
+mobileNavbarToggle.addEventListener('click', toggleMobileNavbarVisibility);
 
 const navMenu = topnav.querySelector('.nav-menu');
 const navLinks = navMenu.querySelector('.nav-links');
 
 navMenu.addEventListener('click', toggleMobileNavbarVisibility);
-navLinks.addEventListener('click', clickEvent => clickEvent.stopPropagation());
+navLinks.addEventListener('click', (clickEvent) => clickEvent.stopPropagation());
 
-(function() {
+(function () {
   const anchors = Array.from(navLinks.querySelectorAll('a'));
 
   let cachedActiveNavlink;
@@ -50,7 +50,7 @@ navLinks.addEventListener('click', clickEvent => clickEvent.stopPropagation());
   // Manually listen to these events to ensure that we never underline two different links
   // simultaneously. For example, if we're on Experience but hovering over Blog, we don't want
   // both links to have a focus style. See onNavLinkHovered for how that's handled.
-  anchors.forEach(anchor => {
+  anchors.forEach((anchor) => {
     anchor.addEventListener('focusin', onNavLinkHovered);
     anchor.addEventListener('mouseenter', onNavLinkHovered);
     anchor.addEventListener('focusout', rehighlightActiveNavLink);
@@ -66,7 +66,7 @@ navLinks.addEventListener('click', clickEvent => clickEvent.stopPropagation());
     if (!activeNavLink) return;
 
     const hoveredAnchor = mouseEvent.target;
-    
+
     if (hoveredAnchor === activeNavLink) return;
 
     cachedActiveNavlink = activeNavLink;
@@ -81,12 +81,3 @@ navLinks.addEventListener('click', clickEvent => clickEvent.stopPropagation());
     }
   }
 })();
-
-document.querySelectorAll('.card').forEach(card => {
-  card.addEventListener('keyup', event => {
-    if (event.keyCode === 13) {
-      const url = card.querySelector('.container-link');
-      window.open(url.getAttribute('href'), '_self');
-    }
-  });
-})

--- a/assets/scripts/copyCode.js
+++ b/assets/scripts/copyCode.js
@@ -1,31 +1,24 @@
 // Temporary text area hack: https://stackoverflow.com/a/46822033/5323344
-const copyCode = copyCodeButton => {
-  const tempTextArea = document.createElement("textarea");
-  tempTextArea.textContent = copyCodeButton.getAttribute("data-code");
+const copyCode = (clickEvent) => {
+  const copyCodeButton = clickEvent.target;
+  const tempTextArea = document.createElement('textarea');
+  tempTextArea.textContent = copyCodeButton.getAttribute('data-code');
   document.body.appendChild(tempTextArea);
 
   const selection = document.getSelection();
   selection.removeAllRanges();
   tempTextArea.select();
-  document.execCommand("copy");
+  document.execCommand('copy');
   selection.removeAllRanges();
   document.body.removeChild(tempTextArea);
 
   // Show "Copied!" and green checkmark
-  copyCodeButton.classList.add("copied");
+  copyCodeButton.classList.add('copied');
   setTimeout(() => {
-    copyCodeButton.classList.remove("copied");
+    copyCodeButton.classList.remove('copied');
   }, 2000);
 };
 
-document.addEventListener("keyup", keyEvent => {
-  if (keyEvent.keyCode === 13) {
-    copyCode(keyEvent.target);
-  }
-});
-
-document.querySelectorAll(".copy-code-button").forEach(copyCodeButton => {
-  copyCodeButton.addEventListener("click", clickEvent =>
-    copyCode(clickEvent.target)
-  );
+document.querySelectorAll('.copy-code-button').forEach((copyCodeButton) => {
+  copyCodeButton.addEventListener('click', copyCode);
 });


### PR DESCRIPTION
Closes #24 

TL;DR: Downloaded NVDA and realized just how annoying it was to navigate my site and its content with a screen reader 😅

## Summary of major changes

### 1. Added a skip navigation link

![image](https://user-images.githubusercontent.com/19352442/81121727-6c1e0c00-8efd-11ea-955d-c9ecc5a7f31d.png)

Keyboard users rejoice!

### 2. Used `button` for actual buttons

e.g., the copy-to-clipboard buttons or the hamburger icon.

Should probably use the checkbox hack for the theme switch, tbh, because it's just a div at this point and not really meaningful.

### 3. Replaced many `footer`s with `ul`s wherever the content was in fact a grouped list of items

For example, the tags at the bottom of a blog post preview card:

![image](https://user-images.githubusercontent.com/19352442/81121951-e353a000-8efd-11ea-8912-27aa1440f6fd.png)

Or the tags at the bottom of a project card:

![image](https://user-images.githubusercontent.com/19352442/81121922-d46ced80-8efd-11ea-94d5-1ba2da8702c2.png)

And so on.

### 4. Used `aria-label` more

This influenced other changes, too, wherever I noticed that the screen reader was not actually picking up on my `aria-label`s.

I found that navigating my site content was painful and unclear from a blind user's perspective, to the point that someone may not know what exactly they're "looking" at. I added descriptive `aria-label`s to clarify these things.

This was most evident with things that weren't lists but that should've been lists (see bullet 3 above):

![image](https://user-images.githubusercontent.com/19352442/81122293-9fad6600-8efe-11ea-9735-c8bfd88b8a4f.png)

## Testing

Used ngrok and the W3 HTML validator to make sure my changes didn't break things (spoiler: they did—but it's all good now!).